### PR TITLE
Replace uri field with user_id field

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -162,7 +162,7 @@ def create_app(config) -> Flask:
                     "email": user.email,
                     "firstname": user.firstname,
                     "lastname": user.lastname,
-                    "uri": f"/users/{user.id}",
+                    "user_id": user.id,
                 }
                 for user in users
             ]


### PR DESCRIPTION
Originally I was going to provide URIs to relevant resources.  I don't think this is necessary so I propose we just include the field variable needed to get to the next resource.

Before this may have returned:
```
{
  ...
  "uri": "library/v0.1/users/1"
  ...
}
```
And now it would be
```
{
  ...
  "user_id": 1
  ...
}
```
Where the value at "user_id" can be used to access details for that user at "library/v0.1/users/{user_id}"